### PR TITLE
Fix code scanning alert no. 18: Cross-site scripting

### DIFF
--- a/WebGoatCore/Views/Shared/_LoginPartial.cshtml
+++ b/WebGoatCore/Views/Shared/_LoginPartial.cshtml
@@ -1,4 +1,5 @@
 ﻿@using Microsoft.AspNetCore.Identity
+@using System.Text.Encodings.Web
 
 @inject SignInManager<IdentityUser> SignInManager
 @inject UserManager<IdentityUser> UserManager
@@ -13,5 +14,5 @@
 }
 else
 {
-    <a class="nav-link text-dark" id="login" asp-controller="Account" asp-action="Login" asp-route-returnUrl="@Context.Request.Path">[ Log In ]</a>
+    <a class="nav-link text-dark" id="login" asp-controller="Account" asp-action="Login" asp-route-returnUrl="@HtmlEncoder.Default.Encode(Context.Request.Path)">[ Log In ]</a>
 }


### PR DESCRIPTION
Fixes [https://github.com/cloudweek/WebGoat.NETCore/security/code-scanning/18](https://github.com/cloudweek/WebGoat.NETCore/security/code-scanning/18)

To fix the cross-site scripting vulnerability, we need to sanitize the user input before it is written to the HTML output. The best way to do this in ASP.NET Core is to use the `HtmlEncoder` class provided by the `System.Text.Encodings.Web` namespace. This class provides methods to encode HTML content, which will prevent XSS attacks by converting special characters to their HTML-encoded equivalents.

We will modify the code to use `HtmlEncoder.Default.Encode` to encode the `Context.Request.Path` value before it is written to the HTML output.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
